### PR TITLE
General: Streamline CI pipeline to only work on PRs to main branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,10 +1,8 @@
 name: Movieo CI Pipeline
 
 on:
-  push:
-    branches: [main, dev]
   pull_request:
-    branches: [main, dev]
+    branches: [main]
 
 jobs:
   test:


### PR DESCRIPTION
By limiting the CI running on only the main branch, we now have the flexibility to work on any sub branch and not be limited to 'dev'