### PR TITLE
General: Streamline CI pipeline to only work on push/PRs to main branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: Movieo CI Pipeline
 
 on:
   push:
-    branches: [main, dev]
+    branches: [main]
   pull_request:
-    branches: [main, dev]
+    branches: [main]
 
 jobs:
   test:


### PR DESCRIPTION
Remove the hard-coded dev branch from triggering the CI, allowing us to have the flexibility to use any branch name and still maintain the requirement for the CI to run on PRs to main